### PR TITLE
Destroys .rpmnew files if not connected to a tty

### DIFF
--- a/source/rpmconf
+++ b/source/rpmconf
@@ -203,7 +203,7 @@ function clean_orphan {
             fi
         done
         if [ -s $FILES_MERGE ]; then
-            echo "This files need merge - you may want to run 'rpmconf -a':"
+            echo "These files need merging - you may want to run 'rpmconf -a':"
             cat $FILES_MERGE
             echo "Skipping files above."
             echo
@@ -212,7 +212,7 @@ function clean_orphan {
         if [ -s $FILES_DELETE ]; then
             echo "Orphaned .rpmnew and .rpmsave files:"
             cat $FILES_DELETE
-            read -u 1 -p "Delete this files (Y/n): " OPTION
+            read -u 1 -p "Delete these files (Y/n): " OPTION
             RC=$?
             if [ $RC -eq 0 ]; then
                 OPTION=$(toUpper "$OPTION")


### PR DESCRIPTION
I ran the following command to upgrade my system to Fedora 19, and found that all .rpmnew files were removed.

```
fedora-upgrade 2>&1 | tee /root//fedora-upgrade.f19.out
```

Here's a snippet from the output:

```
...
Configuration file `/etc/shells'
-rw-r--r--. 1 root root 60 Jan 21 21:15 /etc/shells
-rw-r--r--. 1 root root 76 Jun  7 15:31 /etc/shells.rpmnew
 ==> Package distributor has shipped an updated version.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      M     : merge configuration files
      Z     : background this process to examine the situation
      S     : skip this file
 The default action is to keep your current version.
*** aliases (Y/I/N/O/D/Z/S) [default=N] ? 
/sbin/rpmconf: line 104: read: read error: 1: Bad file descriptor
...
```
