### PR TITLE
overwrite symbol link

### DIFF
--- a/source/rpmconf.py
+++ b/source/rpmconf.py
@@ -16,6 +16,7 @@ from termios import tcflush, TCIOFLUSH
 
 import argparse
 import difflib
+import errno
 import os
 import pydoc
 import re
@@ -35,7 +36,11 @@ def copy(src, dst):
     """ Copy src to dst."""
     if os.path.islink(src):
         linkto = os.readlink(src)
-        os.symlink(linkto, dst)
+        try:
+            os.symlink(linkto, dst)
+        except FileExistsError:
+            os.unlink(dst)
+            os.symlink(linkto, dst)
     else:
         shutil.copy2(src, dst)
 


### PR DESCRIPTION
```
lrwxrwxrwx. 1 root root 20 Oct 17 13:17 /etc/mock/default.cfg -> fedora-21-x86_64.cfg
lrwxrwxrwx. 1 root root 25 Nov 17 22:23 /etc/mock/default.cfg.rpmnew -> fedora-rawhide-x86_64.cfg
```

``` python
Traceback (most recent call last):
  File "/sbin/rpmconf", line 318, in <module>
    main()
  File "/sbin/rpmconf", line 311, in main
    handle_package(args, package_hdr)
  File "/sbin/rpmconf", line 217, in handle_package
    handle_rpmnew(args, conf_file, conf_file + ".rpmnew")
  File "/sbin/rpmconf", line 159, in handle_rpmnew
    overwrite(args, other_file, conf_file)
  File "/sbin/rpmconf", line 43, in overwrite
    copy(src, dst)
  File "/sbin/rpmconf", line 35, in copy
    os.symlink(linkto, dst)
FileExistsError: [Errno 17] File exists: 'fedora-rawhide-x86_64.cfg' ->
'/etc/mock/default.cfg'
```

Reference: https://github.com/xsuchy/rpmconf/issues/11
Signed-off-by: Igor Gnatenko i.gnatenko.brain@gmail.com
