### PR TITLE
Set logging level only for rpmconf logger

### DIFF
--- a/rpmconf/rpmconf.py
+++ b/rpmconf/rpmconf.py
@@ -81,8 +81,8 @@ class RpmConf(object):
         self.frontend = frontend
         self.selinux = selinux
         self.debug = debug
-        logging.basicConfig(level=logging.INFO)
         self.logger = logging.getLogger("rpmconf")
+        self.logger.setLevel(logging.INFO)
 
     def run(self):
         """Main function to proceed"""


### PR DESCRIPTION
dnf-plugins-extras imports rpmconf and RpmConf.\__init\__ reconfigures dnf logging
should resolve rhbug [1284835](https://bugzilla.redhat.com/show_bug.cgi?id=1284835)
