### PR TITLE
1350249 - handle gracefully diff traceback for broken symlink

### DIFF
--- a/rpmconf/rpmconf.py
+++ b/rpmconf/rpmconf.py
@@ -173,7 +173,10 @@ class RpmConf(object):
                                         stdout=subprocess.PIPE,
                                         universal_newlines=True)
             diff = diff_out.communicate()[0]
-        pydoc.pager(err_msg + "".join(diff))
+        try:
+            pydoc.pager(err_msg + "".join(diff))
+        except TypeError:
+            pydoc.pager(err_msg)
 
     @staticmethod
     def is_broken_symlink(file1):


### PR DESCRIPTION
The difflib does not like having file as /dev/null. Handle this
case gracefully by printing only err_msg.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>