### PR TITLE
Drop the deprecated no-op "U" mode for open() to support Python 3.9

### DIFF
--- a/rpmconf/rpmconf.py
+++ b/rpmconf/rpmconf.py
@@ -171,10 +171,10 @@ class RpmConf(object):
         else:
             todate = time.ctime(os.stat(file2).st_mtime)
         try:
-            fromlines = open(file1, "U").readlines()
+            fromlines = open(file1).readlines()
             if fromlines == []:
                 fromlines = [""]
-            tolines = open(file2, "U").readlines()
+            tolines = open(file2).readlines()
             if tolines == []:
                 tolines = [""]
             diff = difflib.unified_diff(fromlines, tolines,


### PR DESCRIPTION
Changed in Python 3.9:

open() no longer accepts 'U' (“universal newline”) in the file mode.
This flag was deprecated since Python 3.3.
In Python 3, the “universal newline” is used by default when a file is open in text mode.
The newline parameter of open() controls how universal newlines works.

Python change: https://bugs.python.org/issue37330

Fedora Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1788922