### PR TITLE
Feature Request: implement unattended mode

### DIFF
--- a/bin/rpmconf
+++ b/bin/rpmconf
@@ -54,6 +54,17 @@ def main():
     parser.add_argument("-o", "--owner", dest="owner", metavar="PACKAGE",
                         nargs="*",
                         help="Check only configuration files of given package.")
+    parser.add_argument("-u", "--unattended", dest="unattended",
+                        choices=["use_maintainer", "use_your", "default"],
+                        nargs="?", const="default", metavar="MODE",
+                        help="Unattended mode: do not prompt user, perform actions "
+                             "based on MODE. use_maintainer replaces existing "
+                             "configuration files with .rpmnew and deletes all "
+                             ".rpmsave files. use_your deletes .rpmnew files and "
+                             "replaces existing configuration files with .rpmsave "
+                             "files. default does use_your for .rpmnew files and "
+                             " use_maintainer for .rpmsave (same as prompts). "
+                             "(default: %(default)s)")
     parser.add_argument("-V", "--version", dest="version", action="store_true",
                         help="Display rpmconf version.")
     parser.add_argument("-x", "--exclude", dest="exclude", metavar="DIRECTORY",
@@ -77,7 +88,8 @@ def main():
                             clean=args.clean, debug=args.debug,
                             diff=args.diff, frontend=args.frontend,
                             selinux=args.selinux, test=args.test,
-                            exclude=args.exclude, root=args.root)
+                            exclude=args.exclude, root=args.root,
+                            unattended=args.unattended)
 
     try:
         rconf.run()

--- a/rpmconf.sgml
+++ b/rpmconf.sgml
@@ -47,6 +47,9 @@
         <arg>-t, --test</arg>
     </cmdsynopsis>
     <cmdsynopsis>
+        <arg>-u, --unattended <replaceable><optional>&lt;MODE&gt;</optional></replaceable></arg>
+    </cmdsynopsis>
+    <cmdsynopsis>
         <arg>-x, --exclude <replaceable>&lt;DIRECTORY&gt;</replaceable></arg>
     </cmdsynopsis>
     <cmdsynopsis>
@@ -134,6 +137,20 @@
                   Just test existence of files to merge. If there is some file to merge then rpmconf
                   will print it and exit with status code 5. If there are none to merge, then exit
                   with status code 0.
+            </para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>-u [&lt;MODE&gt;], --unattended [&lt;MODE&gt;]</term>
+        <listitem>
+            <para>
+                  Unattended mode.
+                  Do not prompt user, but perform actions based on MODE. Valid options are: use_maintainer, use_your, default.
+                  use_maintainer replaces existing configuration files with .rpmnew files and deletes leftover .rpmsave and
+                  .rpmorig files. use_your deletes .rpmnew files and replaces existing configuration files with .rpmsave files.
+                  default does use_your for .rpmnew files and use_maintainer for .rpmsave files, as are the default prompts
+                  in interactive mode.
+                  Specifying MODE is optional, default is used by default.
             </para>
         </listitem>
     </varlistentry>


### PR DESCRIPTION
Hello Miroslav,

we have a use case when we would really appreciate if rpmconf could work in "yes to all"/"unattended" mode. Since we manage systems with Puppet anyway, we would run rpmconf -a (via dnf plugin after package installations) to install all .rpmnew files as new configuration files and then Puppet would run anyway and modify configuration files according to our specification.

I have implemented draft patch for rpmconf which introduces -u/--unattended parameter which basically performs as if user would answer each prompt with 'Y' / 'I'. I am not sure if -u is OK, or -U or -y would be better, this is just a proposal.