### PR TITLE
Check if package config file exists before processing it

### DIFF
--- a/rpmconf/rpmconf.py
+++ b/rpmconf/rpmconf.py
@@ -331,6 +331,10 @@ class RpmConf(object):
     def _handle_package(self, package):
         result = 0
         for conf_file in self.get_list_of_config(package):
+            #pylint: disable=no-member
+            if not os.path.exists(conf_file):
+                # see https://github.com/xsuchy/rpmconf/issues/49
+                continue
             if self.diff:
                 conf_rpmnew = "{0}.rpmnew".format(conf_file)
                 conf_rpmsave = "{0}.rpmsave".format(conf_file)


### PR DESCRIPTION
Sometimes it may happen that config file is deleted while package conf keep record about it.
Before this patch rpmconf was dying with FileNotFound exception. With this patch we simply
skipping such file and continue.