### PR TITLE
Remove deprecated no-op setInterruptSafety() call

### DIFF
--- a/rpmconf/rpmconf.py
+++ b/rpmconf/rpmconf.py
@@ -43,7 +43,7 @@ import termios
 
 __version__ = "1.0.60"
 
-if rpm.__version__ > "4.13.0":
+if rpm.__version__ > "4.13.0" and rpm.__version__ < "4.18.0":
     rpm.setInterruptSafety(False)
 
 


### PR DESCRIPTION
This function no longer has any effect in RPM since the removal of the Berkeley DB backend in RPM 4.16.  The Python binding has been deprecated for a while now, and is completely gone in RPM 4.19, so let's move with the times.

More info here:

  https://github.com/rpm-software-management/rpm/pull/1946
  https://github.com/rpm-software-management/rpm/pull/1992
  https://github.com/rpm-software-management/rpm/pull/1994