### PR TITLE
Use rpm.files instead of rpm.fi

### DIFF
--- a/rpmconf/rpmconf.py
+++ b/rpmconf/rpmconf.py
@@ -43,7 +43,7 @@ import termios
 
 __version__ = "1.0.60"
 
-if rpm.__version__ > "4.13.0":
+if rpm.__version__ > "4.13.0" and rpm.__version__ < "4.18.0":
     rpm.setInterruptSafety(False)
 
 

--- a/rpmconf/rpmconf.py
+++ b/rpmconf/rpmconf.py
@@ -154,11 +154,11 @@ class RpmConf(object):
         :rtype: list
 
         """
-        files = rpm.fi(package) # pylint: disable=no-member
+        files = rpm.files(package) # pylint: disable=no-member
         result = []
         for rpm_file in files:
-            if rpm_file[4] & rpm.RPMFILE_CONFIG: # pylint: disable=no-member
-                file_name = rpm_file[0]
+            if rpm_file.fflags & rpm.RPMFILE_CONFIG: # pylint: disable=no-member
+                file_name = rpm_file.name
                 if self.root:
                     file_name = os.path.normpath(self.root + file_name)
                 result.append(file_name)


### PR DESCRIPTION
This finished porting to RPM 4.19. It fixes "module 'rpm' has no attribute 'fi' error.
It is based on #52.