### PR TITLE
Add CLI flag '--diff-frontend' to set diff display.

### DIFF
--- a/bin/rpmconf
+++ b/bin/rpmconf
@@ -29,6 +29,10 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-a", "--all", dest="all", action="store_true",
                         help="Check configuration files of all packages.")
+    parser.add_argument("--diff-frontend", dest="diff_frontend", action="store",
+                        metavar="DIFF",
+                        help="Define which frontend should be used for displaying diff."
+                             " For list of valid types see man page.")
     parser.add_argument("-c", "--clean", dest="clean", action="store_true",
                         help="Find and delete orphaned"
                              " .rpmnew and .rpmsave files.")
@@ -38,7 +42,7 @@ def main():
                         help="Non-interactive diff mode. "
                              "Useful to audit configs. "
                              "Use with -a or -o options.")
-    parser.add_argument("-f", "--frontend", dest="frontend", action="store",
+    parser.add_argument("-f", "--frontend", "--merge-frontend", dest="merge_frontend", action="store",
                         metavar="EDITOR",
                         help="Define which frontend should be used for merging."
                              " For list of valid types see man page.")
@@ -86,10 +90,11 @@ def main():
 
     rconf = rpmconf.RpmConf(packages=None if args.all else owner,
                             clean=args.clean, debug=args.debug,
-                            diff=args.diff, frontend=args.frontend,
+                            diff=args.diff, merge_frontend=args.merge_frontend,
                             selinux=args.selinux, test=args.test,
                             exclude=args.exclude, root=args.root,
-                            unattended=args.unattended)
+                            unattended=args.unattended,
+                            diff_frontend=args.diff_frontend)
 
     try:
         rconf.run()

--- a/rpmconf.sgml
+++ b/rpmconf.sgml
@@ -29,7 +29,7 @@
         <arg>-o<replaceable>&lt;package&gt;</replaceable>, --owner=<replaceable>&lt;package&gt;</replaceable></arg>
     </cmdsynopsis>
     <cmdsynopsis>
-        <arg>-f<replaceable>&lt;type&gt;</replaceable> --frontend=<replaceable>&lt;type&gt;</replaceable></arg>
+        <arg>-f<replaceable>&lt;type&gt;</replaceable> --frontend=<replaceable>&lt;type&gt;</replaceable> --merge-frontend=<replaceable>&lt;type&gt;</replaceable></arg>
     </cmdsynopsis>
     <cmdsynopsis>
         <arg>--root <replaceable>&lt;ROOT&gt;</replaceable></arg>
@@ -92,9 +92,15 @@
         </listitem>
     </varlistentry>
     <varlistentry>
-        <term>-f&lt;type&gt;, --frontend=&lt;type&gt;</term>
+        <term>-f&lt;type&gt;, --frontend=&lt;type&gt;, --merge-frontend=&lt;type&gt;</term>
         <listitem>
-            <para>Define which frontend should be used for merging. Valid options are: vimdiff, gvimdiff, diffuse, kdiff3, meld, sdiff and env. When set to env, the command to use is taken from the environment variable $MERGE. The default is env.</para>
+            <para>Define which frontend should be used for merging. Valid options are: vimdiff, gvimdiff, diffuse, kdiff3, kompare, meld, sdiff and env. When set to env, the command to use is taken from the environment variable $MERGE. The default is env.</para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>--diff-frontend=&lt;type&gt;</term>
+        <listitem>
+            <para>Define which external frontend should be used for displaying diffs. Valid options are: vimdiff, gvimdiff, diffuse, kdiff3, kompare, meld, sdiff and env. When set to env, the command to use is taken from the environment variable $DIFF. The default is to use the internal Python diff.</para>
         </listitem>
     </varlistentry>
     <varlistentry>

--- a/rpmconf.spec
+++ b/rpmconf.spec
@@ -39,9 +39,11 @@ BuildRequires:  python%{python3_pkgversion}-six
 %if 0%{?rhel} == 7
   # nothing
 %else
+Suggests: colordiff
 Suggests: diffuse
 Suggests: diffutils
 Suggests: kdiff3
+Suggests: kompare
 Suggests: meld
 Suggests: vim-X11
 Suggests: vim-enhanced


### PR DESCRIPTION
- Support for all merge frontends as diff frontends.
- Add support for `colordiff` and `diff` as diff frontends.
- Add support for `kompare` as a merge and diff frontend.
- Add synonym flag '--merge-frontend' for '--frontend'.

Fixes xsuchy/rpmconf#48